### PR TITLE
[#1222] Revert back to using a single pipeline

### DIFF
--- a/datapackage_pipelines_fiscal/helpers.py
+++ b/datapackage_pipelines_fiscal/helpers.py
@@ -1,0 +1,13 @@
+def run_after_yielding_elements(resource_iterator, callback):
+    '''Yields all iterator's elements, runs callback, and stops iteration.
+
+    This method is useful when you want to run your processor's code after all
+    previous processors have finished, but block subsequent processors from
+    running before you're finished.
+    '''
+    while True:
+        try:
+            yield next(resource_iterator)
+        except StopIteration:
+            callback()
+            raise

--- a/datapackage_pipelines_fiscal/processors/upload.py
+++ b/datapackage_pipelines_fiscal/processors/upload.py
@@ -4,6 +4,7 @@ import zipfile
 import tempfile
 
 from datapackage_pipelines.wrapper import ingest, spew
+import datapackage_pipelines_fiscal.helpers as helpers
 
 import gobble
 
@@ -23,20 +24,31 @@ def line_counter(_res_iter):
         yield process_rows(res)
 
 
-spew(datapackage, line_counter(res_iter))
+def run():
+    user = gobble.user.User()
+    publish = params.get('publish', False)
+    in_filename = open(params['in-file'], 'rb')
 
-user = gobble.user.User()
-in_filename = open(params['in-file'], 'rb')
+    in_file = zipfile.ZipFile(in_filename)
+    temp_dir = tempfile.mkdtemp()
+    for name in in_file.namelist():
+        in_file.extract(name, temp_dir)
+        in_file.close()
+        datapackage_json = os.path.join(temp_dir, 'datapackage.json')
+        datapackage = json.load(open(datapackage_json))
+        datapackage['count_of_rows'] = line_count
+        json.dump(datapackage, open(datapackage_json, 'w'))
 
-in_file = zipfile.ZipFile(in_filename)
-temp_dir = tempfile.mkdtemp()
-for name in in_file.namelist():
-    in_file.extract(name, temp_dir)
-in_file.close()
-datapackage_json = os.path.join(temp_dir, 'datapackage.json')
-datapackage = json.load(open(datapackage_json))
-datapackage['count_of_rows'] = line_count
-json.dump(datapackage, open(datapackage_json, 'w'))
+        package = gobble.fiscal.FiscalDataPackage(datapackage_json, user=user)
+        package.upload(skip_validation=True, publish=publish)
 
-package = gobble.fiscal.FiscalDataPackage(datapackage_json, user=user)
-package.upload(skip_validation=True, publish=params.get('publish', False))
+
+# Wrap iterator using helpers.run_after_yielding_elements() so we
+# guarantee that this processor is run after every processor before
+# it has finished, but will block subsequent processors that use this
+# wrapper from running until it's finished.
+iterator = helpers.run_after_yielding_elements(
+    line_counter(res_iter),
+    lambda: run()
+)
+spew(datapackage, iterator)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,20 @@
+import datapackage_pipelines_fiscal.helpers as helpers
+import unittest.mock as mock
+
+
+class TestHelpers(object):
+    def test_run_after_yielding_elements(self):
+        resources = [
+            'resource 1',
+            'resource 2',
+        ]
+        callback = mock.MagicMock()
+        iterator = helpers.run_after_yielding_elements(iter(resources), callback)
+
+        while True:
+            try:
+                next(iterator)
+                callback.assert_not_called()
+            except StopIteration:
+                callback.assert_called_once()
+                break


### PR DESCRIPTION
We tried using 3 different pipelines as a way to guarantee that their
processors would run only when the previous were finished. Unfortunately, this
caused another issue.

Consider that we have pipelines A and B, where B depends on A. Some processor
in pipeline A saves a datapackage to the local filesystem, for B to process
further. Now, *os-data-importers* is deployed, it runs pipeline A succesfully,
which writes the datapackage to the filesystem. Then, before B is able to
execute, the *os-data-importers* is re-deployed. As its filesystem isn't
persistent, all of its files are lost, including the datapackage written by A.

Later, the new deployment finishes. The datapackage-pipeline will see that A
was successful, and wasn't modified, so doesn't run it again, and go on to run
B. This is where we have problems. B depends on the zip file created by A, but
that file doesn't exist anymore, so B raises an exception and stops.

This is where we get stuck. The datapackage-pipeline isn't aware of this zip
file dependency of B, so it doesn't know it has to trigger A again.

The solution for this was to get them all to the same pipeline. However, we now
have to find a way to run a processor only after all previous processors were
finished. The usual way we've been doing is by simply calling `spew()`, and
then running the processor's code. This don't work for us because we have more
than one processor that needs to run after everybody before it has finished.
Bear with me, because this is a bit complicated.

Let's consider a pipeline with 2 processors:

1. modify_datapackage_and_write_to_zip
2. fiscal.upload

The code for the first processor looks like:
```python
from datapackage_pipelines.wrapper import ingest, spew

parameters, datapackage, resource_iterator = ingest()
spew(datapackage, resource_iterator)  # Pass the dp and resources as is

run_and_save_to('datapackage.zip')  # Run this processor and save DP to path
```

Notice that, in the end, it saves a datapackage to the local filesystem. This
datapackage is used by the next processor, `fiscal.upload`. Its code would look
like:

```python
from datapackage_pipelines.wrapper import ingest, spew

parameters, datapackage, resource_iterator = ingest()
spew(datapackage, resource_iterator)  # Pass the dp and resources as is

upload_datapackage('datapackage.zip')  # This came from the previous processor
```

The problem is that this `spew()` technique only guarantees that no previous
task will be ingesting data that's passing through the pipeline. However, we're
here using data outside of the pipeline. It's possible that
`upload_datapackage()` starts running before `run_and_save_to()` has finished.
We need to block the following processors until the entirety of the previous
processors has run, even code outside `spew()`.

The solution for this was a hack. You can see the code in
`helpers.run_after_yielding_elements()`. It receives an iterator, yields all of
its elements, but before raising `StopIteration`, it runs a callback. Its code
is very short:

```python
def run_after_yielding_elements(resource_iterator, callback):
    while True:
        try:
            yield next(resource_iterator)
        except StopIteration:
            callback()
            raise
```

This allow us to block `spew()` after it has received all resources (so we
guarantee that datapackage's data passed through our processor).

This is a hack, and ideally we wouldn't have to write it. However, this is the
simplest solution I found without having to modify datapackage-pipelines itself.

Fixes openspending/openspending#1222